### PR TITLE
Fix gcc version compilation difference during code gen

### DIFF
--- a/cse.c
+++ b/cse.c
@@ -5660,7 +5660,7 @@ fold_rtx (x, insn)
 	     hence not save anything) or be incorrect.  */
 	  if (const_arg1 != 0 && GET_CODE (const_arg1) == CONST_INT
 	      && INTVAL (const_arg1) < 0
-	      && - INTVAL (const_arg1) >= 0
+	      && (-INTVAL (const_arg1) >> 0x1f) >= 0
 	      && GET_CODE (folded_arg1) == REG)
 	    {
 	      rtx new_const = GEN_INT (- INTVAL (const_arg1));


### PR DESCRIPTION
GCC 9 optimizes negative value checks differently than v6, namely shift left by 1 then check the carry bit while GCC 6 negates then shifts everything to the right to see if any value exists. This causes issues when using a value of 0x80000000 causing an instruction flip  between addu and subu during mips code gen.

This patch allows compiling with newer gcc versions while still generating the same mips code for paper mario and other older mips based systems.