### PR TITLE
Fix abbrev bug during compilation causing gdb failure to load elf

### DIFF
--- a/dwarf2out.c
+++ b/dwarf2out.c
@@ -4918,6 +4918,7 @@ output_abbrev_section ()
 
       fprintf (asm_out_file, "\t%s\t0,0\n", ASM_BYTE_OP);
     }
+  fprintf (asm_out_file, "\t%s\t0\n", ASM_BYTE_OP);
 }
 
 /* Output location description stack opcode's operands (if any).  */


### PR DESCRIPTION
The abbrev debug table was not properly terminated causing gdb itself to crash during loading of papermario.elf