### PR TITLE
Changes to fix stab data generation data for line offsets

### DIFF
--- a/config/mips/gnu.h
+++ b/config/mips/gnu.h
@@ -39,6 +39,8 @@ Boston, MA 02111-1307, USA.  */
 #undef TARGET_VERSION
 #define TARGET_VERSION fprintf (stderr, " (MIPS GNU/ELF)");
 
+extern char *current_function_name;
+
 /* Output at beginning of assembler file.  */
 /* The .file command should always begin the output.  */
 #undef ASM_FILE_START
@@ -60,8 +62,8 @@ Boston, MA 02111-1307, USA.  */
 #define ASM_OUTPUT_SOURCE_LINE(FILE, LINE)				\
   do {									\
       ++sym_lineno;							\
-      fprintf ((FILE), ".LM%d:\n\t%s %d,0,%d,.LM%d\n",			\
-	       sym_lineno, ASM_STABN_OP, N_SLINE, (LINE), sym_lineno);	\
+      fprintf ((FILE), ".LM%d:\n\t%s %d,0,%d,.LM%d-%s\n",			\
+	       sym_lineno, ASM_STABN_OP, N_SLINE, (LINE), sym_lineno, current_function_name);	\
   } while (0)
 
 #undef ASM_DECLARE_FUNCTION_NAME

--- a/dbxout.c
+++ b/dbxout.c
@@ -81,6 +81,8 @@ Boston, MA 02111-1307, USA.  */
 #include "defaults.h"
 #include "output.h" /* ASM_OUTPUT_SOURCE_LINE may refer to sdb functions.  */
 
+char *current_function_name;
+
 #ifndef errno
 extern int errno;
 #endif
@@ -563,7 +565,6 @@ dbxout_source_line (file, filename, lineno)
      int lineno;
 {
   dbxout_source_file (file, filename);
-
 #ifdef ASM_OUTPUT_SOURCE_LINE
   ASM_OUTPUT_SOURCE_LINE (file, lineno);
 #else
@@ -1670,6 +1671,7 @@ dbxout_symbol (decl, local)
 		 IDENTIFIER_POINTER (DECL_ASSEMBLER_NAME (decl)),
 		 IDENTIFIER_POINTER (DECL_NAME (context)));
 
+      current_function_name = IDENTIFIER_POINTER (DECL_ASSEMBLER_NAME (decl));
       dbxout_finish_symbol (decl);
       break;
 


### PR DESCRIPTION
Line data in stabs is function relative instead of absolute, needed change for soon incoming change for assembler