### PR TITLE
Fix off by 1 errors in line generation resulting in mangled line information for decompilation

### DIFF
--- a/dwarf2out.c
+++ b/dwarf2out.c
@@ -4659,7 +4659,7 @@ size_of_line_info ()
 	  size += size_of_uleb128 (current_file);
 	}
 
-      if (line_info->dw_line_num != current_line)
+      //if (line_info->dw_line_num != current_line)
 	{
 	  line_offset = line_info->dw_line_num - current_line;
 	  line_delta = line_offset - DWARF_LINE_BASE;


### PR DESCRIPTION
During creation of the debug_line section there is an off by 1 error when the line number is repeated during calculating the size of the section itself for the first field. Later all of the fields are written out including back to back lines that don't alter the line number itself.